### PR TITLE
change to noUnionInference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@8128-33550336/typedeventemitter",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@8128-33550336/typedeventemitter",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "events": "^3.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8128-33550336/typedeventemitter",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "typedEventEmitter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/eventEmitter.d.ts
+++ b/src/eventEmitter.d.ts
@@ -1,12 +1,12 @@
 import EventEmitter from "events";
 
-type noUnion<T> = T[] extends (T extends T ? T[] : never) ? T : never;
+type noUnionInference<T> = T extends T ? T : never;
 
 export type EventType = { [P in string]: unknown[] };
 
 export declare class TypedEventEmitter<E extends EventType> {
     constructor(options?: ConstructorParameters<typeof EventEmitter>[0]);
-    emit<T extends keyof E>(event: T, ...args: E[noUnion<T>]): boolean;
+    emit<T extends keyof E>(event: T, ...args: E[noUnionInference<T>]): boolean;
     on<T extends keyof E>(event: T, listener: (...args: E[T]) => void): this;
     once<T extends keyof E>(event: T, listener: (...args: E[T]) => void): this;
     off<T extends keyof E>(event: T, listener: (...args: E[T]) => void): this;


### PR DESCRIPTION
```ts
const ee = new TypedEventEmitter<{
    a: ['a'],
    b: ['b'],
}>();
const events: 'a' | 'b' = 'a';
ee.emit(events, events);
```
ができなかったので,修正.