### PR TITLE
fix bug

### DIFF
--- a/src/eventEmitter.d.ts
+++ b/src/eventEmitter.d.ts
@@ -1,12 +1,15 @@
 import EventEmitter from "events";
 
 type noUnionInference<T> = T extends T ? T : never;
+type small<T, S> = S extends T ? S : T;
+
+type a = noUnionInference<'a' | 'b'>;
 
 export type EventType = { [P in string]: unknown[] };
 
 export declare class TypedEventEmitter<E extends EventType> {
     constructor(options?: ConstructorParameters<typeof EventEmitter>[0]);
-    emit<T extends keyof E>(event: T, ...args: E[noUnionInference<T>]): boolean;
+    emit<T extends keyof E>(event: T, ...args: E[noUnionInference<small<typeof event, T>>]): boolean;
     on<T extends keyof E>(event: T, listener: (...args: E[T]) => void): this;
     once<T extends keyof E>(event: T, listener: (...args: E[T]) => void): this;
     off<T extends keyof E>(event: T, listener: (...args: E[T]) => void): this;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,6 +18,7 @@ test('basic', (t, done) => {
     }> = ee;
 
     a.emit('a', 'b');
+    a.emit('a' as 'a' | 'c', 'b' as 'b' | 'd');
     //a.emit('a', 'd');
 });
 
@@ -37,3 +38,19 @@ test('EventType test', (t) => {
     ]);
     const et: EventType[] = types;
 });
+
+const k = ['a', 'b', 'c'] as const;
+type j = { [P in typeof k extends readonly (infer T)[] ? T : never]: [name: P] } & { keydown: [name: string]; };
+
+type noUnionInference<T> = T extends T ? T : never;
+
+const ee = new TypedEventEmitter<j>();
+const a: keyof j = 'b' as keyof j;
+ee.emit(a, a);
+//ee.emit('a', 'b');
+
+type small<T, S> = S extends T ? S : T;
+
+const em = <T extends keyof j>(f: T, ...s: j[noUnionInference<small<typeof f, T>>]) => f;
+em('a' as 'a' | 'b', 'b' as 'a' | 'b');
+//em('a', 'b');


### PR DESCRIPTION
```ts
const ee2 = new TypedEventEmitter<{ [P in 'a' | 'b']: [name: P] } & { c: [name: string]; }>();
ee2.emit('a', 'c');
```
にエラーを出すため.